### PR TITLE
Add formulas for PHP versions 8.2, 8.3, and 8.4

### DIFF
--- a/Formula/lsphp81.rb
+++ b/Formula/lsphp81.rb
@@ -1,0 +1,295 @@
+class Lsphp81 < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  # Should only be updated if the new version is announced on the homepage, https://www.php.net/
+  url "https://www.php.net/distributions/php-8.1.34.tar.xz"
+  mirror "https://fossies.org/linux/www/php-8.1.34.tar.xz"
+  sha256 "ffa9e0982e82eeaea848f57687b425ed173aa278fe563001310ae2638db5c251"
+  license "PHP-3.01"
+
+  livecheck do
+    url "https://www.php.net/releases/feed.php"
+    regex(/PHP (\d+(?:\.\d+)+) /i)
+  end
+
+  head do
+    url "https://github.com/php/php-src.git"
+
+    depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
+    depends_on "re2c" => :build # required to generate PHP lexers
+  end
+
+  depends_on "puleeno/openlitespeed/openlitespeed" => [:build]
+  depends_on "pkg-config" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libffi"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    on_macos do
+      # Ensure that libxml2 will be detected correctly in older MacOS
+      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
+    end
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+
+    config_path = etc/"lsphp/#{version.major_minor}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from hardcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    on_macos do
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    on_linux do
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    on_macos do
+      headers_path = "=#{MacOS.sdk_path_if_needed}/usr"
+    end
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --with-litespeed
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-exif
+      --enable-ftp
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xmlrpc
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    on_macos do
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    on_linux do
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
+      "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    inreplace "php.ini-development", /; ?openssl\.cafile=/,
+      "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+    inreplace "php.ini-development", /; ?openssl\.capath=/,
+      "openssl.capath = \"#{openssl.pkgetc}/certs\""
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".")
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 @@ dnl
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then

--- a/Formula/lsphp82.rb
+++ b/Formula/lsphp82.rb
@@ -1,0 +1,295 @@
+class Lsphp82 < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  # Should only be updated if the new version is announced on the homepage, https://www.php.net/
+  url "https://www.php.net/distributions/php-8.2.31.tar.xz"
+  mirror "https://fossies.org/linux/www/php-8.2.31.tar.xz"
+  sha256 "95eae411d594fe6f6e5678b76645dc13ae47d3c0a5325c1d969b58dea56ee45a"
+  license "PHP-3.01"
+
+  livecheck do
+    url "https://www.php.net/releases/feed.php"
+    regex(/PHP (\d+(?:\.\d+)+) /i)
+  end
+
+  head do
+    url "https://github.com/php/php-src.git"
+
+    depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
+    depends_on "re2c" => :build # required to generate PHP lexers
+  end
+
+  depends_on "puleeno/openlitespeed/openlitespeed" => [:build]
+  depends_on "pkg-config" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libffi"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    on_macos do
+      # Ensure that libxml2 will be detected correctly in older MacOS
+      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
+    end
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+
+    config_path = etc/"lsphp/#{version.major_minor}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from hardcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    on_macos do
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    on_linux do
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    on_macos do
+      headers_path = "=#{MacOS.sdk_path_if_needed}/usr"
+    end
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --with-litespeed
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-exif
+      --enable-ftp
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xmlrpc
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    on_macos do
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    on_linux do
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
+      "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    inreplace "php.ini-development", /; ?openssl\.cafile=/,
+      "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+    inreplace "php.ini-development", /; ?openssl\.capath=/,
+      "openssl.capath = \"#{openssl.pkgetc}/certs\""
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".")
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 @@ dnl
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then

--- a/Formula/lsphp83.rb
+++ b/Formula/lsphp83.rb
@@ -1,0 +1,295 @@
+class Lsphp83 < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  # Should only be updated if the new version is announced on the homepage, https://www.php.net/
+  url "https://www.php.net/distributions/php-8.3.31.tar.xz"
+  mirror "https://fossies.org/linux/www/php-8.3.31.tar.xz"
+  sha256 "66410cee07f4b2baeb0843140bb2a2b52ef930b5cf9b3d6e6d158b33aae8fa37"
+  license "PHP-3.01"
+
+  livecheck do
+    url "https://www.php.net/releases/feed.php"
+    regex(/PHP (\d+(?:\.\d+)+) /i)
+  end
+
+  head do
+    url "https://github.com/php/php-src.git"
+
+    depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
+    depends_on "re2c" => :build # required to generate PHP lexers
+  end
+
+  depends_on "puleeno/openlitespeed/openlitespeed" => [:build]
+  depends_on "pkg-config" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libffi"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    on_macos do
+      # Ensure that libxml2 will be detected correctly in older MacOS
+      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
+    end
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+
+    config_path = etc/"lsphp/#{version.major_minor}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from hardcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    on_macos do
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    on_linux do
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    on_macos do
+      headers_path = "=#{MacOS.sdk_path_if_needed}/usr"
+    end
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --with-litespeed
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-exif
+      --enable-ftp
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xmlrpc
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    on_macos do
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    on_linux do
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
+      "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    inreplace "php.ini-development", /; ?openssl\.cafile=/,
+      "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+    inreplace "php.ini-development", /; ?openssl\.capath=/,
+      "openssl.capath = \"#{openssl.pkgetc}/certs\""
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir"  => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".")
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 ##
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then

--- a/Formula/lsphp84.rb
+++ b/Formula/lsphp84.rb
@@ -1,0 +1,296 @@
+class Lsphp84 < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  # Should only be updated if the new version is announced on the homepage, https://www.php.net/
+  url "https://www.php.net/distributions/php-8.4.22.tar.xz"
+  mirror "https://fossies.org/linux/www/php-8.4.22.tar.xz"
+  sha256 "696c0f6ad92e94c59059c1eb6e300842b8d050934226efcdf00f2a413cb083cf"
+  license "PHP-3.01"
+
+  livecheck do
+    url "https://www.php.net/releases/feed.php"
+    regex(/PHP (\d+(?:\.\d+)+) /i)
+  end
+
+  head do
+    url "https://github.com/php/php-src.git"
+
+    depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
+    depends_on "re2c" => :build # required to generate PHP lexers
+  end
+
+  depends_on "puleeno/openlitespeed/openlitespeed" => [:build]
+  depends_on "pkg-config" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libffi"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    on_macos do
+      # Ensure that libxml2 will be detected correctly in older MacOS
+      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
+    end
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+
+    config_path = etc/"lsphp/#{version.major_minor}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from hardcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    on_macos do
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    on_linux do
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    on_macos do
+      headers_path = "=#{MacOS.sdk_path_if_needed}/usr"
+    end
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --with-litespeed
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-exif
+      --enable-ftp
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xmlrpc
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    on_macos do
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    on_linux do
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
+      "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    inreplace "php.ini-development", /; ?openssl\.cafile=/,
+      "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+    inreplace "php.ini-development", /; ?openssl\.capath=/,
+      "openssl.capath = \"#{openssl.pkgetc}/certs\""
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".")
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 ##
+ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 ##
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then


### PR DESCRIPTION
- Introduced `lsphp82.rb` for PHP 8.2.31 with necessary dependencies and configuration.
- Introduced `lsphp83.rb` for PHP 8.3.31 with similar setup and adjustments for compatibility.
- Introduced `lsphp84.rb` for PHP 8.4.22, maintaining consistency with previous versions.
- Each formula includes a patch to address library linking issues on macOS.
- Configurations for PECL and OpenSSL certificate paths are set for all versions.